### PR TITLE
Add new features, config, logging, retry logic, and app improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,9 @@ import os
 import re
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 import io
+import joblib
 from src.load import load_data
 
 st.set_page_config(layout='wide')
@@ -24,7 +26,7 @@ st.markdown(
 
 st.title("NFL Scoring Predictions")
 
-tab1, tab2, tab3 = st.tabs(['Predictions', 'About', 'Performance'])
+tab1, tab2, tab3, tab4 = st.tabs(['Predictions', 'About', 'Performance', 'Model Insights'])
 
 with tab1:
     pred_dir = "predictions"
@@ -71,20 +73,48 @@ with tab1:
     if 'total_line' in display_df.columns:
         display_df['total_line'] = display_df['total_line'].round(1)
 
+    # Edge column: how far the model's prediction deviates from the Vegas line
+    if 'total_line' in display_df.columns and 'predicted_total' in display_df.columns:
+        display_df['edge'] = (display_df['predicted_total'] - display_df['total_line']).round(1)
+        display_df['edge_str'] = display_df['edge'].apply(
+            lambda x: f"+{x:.1f}" if x > 0 else f"{x:.1f}" if not pd.isna(x) else ""
+        )
+
     display_df = display_df.rename(
         columns={
             "date": "Game Date",
             "home_team": "Home",
             "away_team": "Away",
-            "predicted_total": "Predicted Points",
-            "actual_total": "Actual Points",
-            "total_line": "DraftKings Total"
+            "predicted_total": "Predicted",
+            "actual_total": "Actual",
+            "total_line": "DraftKings Total",
         }
     )
 
-    display_df['Actual Points'] = display_df['Actual Points'].apply(
+    display_df['Actual'] = display_df['Actual'].apply(
         lambda x: '' if pd.isnull(x) else int(x) if float(x).is_integer() else x
     )
+
+    # Build styled table
+    cols_to_show = ["Game Date", "Home", "Away", "DraftKings Total", "Predicted", "edge_str", "Actual"]
+    cols_to_show = [c for c in cols_to_show if c in display_df.columns]
+    styled = display_df[cols_to_show].rename(columns={"edge_str": "Edge"})
+
+    # Color the Edge column: green = lean over (positive), red = lean under (negative)
+    PRECISION = 4.0
+
+    def _color_edge(val):
+        try:
+            num = float(val.replace("+", ""))
+        except (ValueError, AttributeError):
+            return ""
+        if num >= PRECISION:
+            return "background-color: #d4edda; color: #155724; font-weight: bold"  # green
+        if num <= -PRECISION:
+            return "background-color: #f8d7da; color: #721c24; font-weight: bold"  # red
+        return ""
+
+    styled_df = styled.style.applymap(_color_edge, subset=["Edge"])
 
     st.markdown(
         """
@@ -103,9 +133,9 @@ with tab1:
     )
 
     st.dataframe(
-        display_df[["Game Date", "Home", "Away", "DraftKings Total", "Predicted Points", "Actual Points"]],
+        styled_df,
         use_container_width=True,
-        hide_index=True
+        hide_index=True,
     )
 
     st.markdown(
@@ -145,7 +175,7 @@ with tab2:
 
 with tab3:
     perf_df = predictions.copy()
-    
+
     if 'actual_total' in perf_df.columns:
         perf_df = perf_df.replace('', np.nan)
         perf_df['actual_total'] = pd.to_numeric(perf_df['actual_total'], errors='coerce')
@@ -193,7 +223,6 @@ with tab3:
             ax.set_ylabel("Number of Games")
             plt.xticks(rotation=0)
 
-            # White count labels inside bars
             for bar in bars:
                 height = bar.get_height()
                 ax.text(
@@ -230,7 +259,6 @@ with tab3:
                 ax.set_ylabel("Number of Games")
                 plt.xticks(rotation=0)
 
-                # White count labels inside bars
                 for bar in bars:
                     height = bar.get_height()
                     ax.text(
@@ -244,3 +272,115 @@ with tab3:
                 buf.seek(0)
                 plt.close(fig)
                 st.image(buf.getvalue(), width=600)
+
+            # --- Section 3: Weekly accuracy trend ---
+            if 'week' in perf_df.columns or 'date' in perf_df.columns:
+                st.header("Weekly Accuracy Trend")
+
+                trend_df = perf_df.copy()
+                if 'week' not in trend_df.columns:
+                    start_date = datetime(2025, 9, 4)
+                    trend_df['date'] = pd.to_datetime(trend_df['date'])
+                    trend_df['week'] = ((trend_df['date'] - start_date).dt.days // 7 + 1).clip(lower=1)
+
+                def is_correct(row):
+                    if pd.isna(row['total_line']):
+                        return None
+                    return int(
+                        (row['actual_total'] > row['total_line']) == (row['predicted_total'] > row['total_line'])
+                    )
+
+                trend_df['correct'] = trend_df.apply(is_correct, axis=1)
+                trend_df = trend_df.dropna(subset=['correct'])
+
+                weekly = (
+                    trend_df.groupby('week')['correct']
+                    .agg(accuracy='mean', n='count')
+                    .reset_index()
+                )
+                weekly['accuracy_pct'] = (weekly['accuracy'] * 100).round(1)
+
+                if not weekly.empty:
+                    fig, ax = plt.subplots(figsize=(8, 4))
+                    ax.plot(weekly['week'], weekly['accuracy_pct'], marker='o', linewidth=2, color='steelblue')
+                    ax.axhline(50, linestyle='--', color='gray', linewidth=1, label='50% baseline')
+                    ax.set_xlabel("Week")
+                    ax.set_ylabel("Accuracy (%)")
+                    ax.set_title("Over/Under Accuracy by Week")
+                    ax.yaxis.set_major_formatter(mticker.PercentFormatter())
+                    ax.legend()
+                    plt.tight_layout()
+                    buf = io.BytesIO()
+                    fig.savefig(buf, format='png', bbox_inches='tight')
+                    buf.seek(0)
+                    plt.close(fig)
+                    st.image(buf.getvalue(), width=700)
+
+            # --- Section 4: Calibration scatter ---
+            st.header("Calibration: Predicted vs Actual Total Points")
+            cal_df = perf_df.dropna(subset=['predicted_total', 'actual_total'])
+            if not cal_df.empty:
+                fig, ax = plt.subplots(figsize=(6, 6))
+                ax.scatter(cal_df['predicted_total'], cal_df['actual_total'],
+                           alpha=0.5, color='steelblue', edgecolors='none', s=30)
+                lo = min(cal_df['predicted_total'].min(), cal_df['actual_total'].min()) - 5
+                hi = max(cal_df['predicted_total'].max(), cal_df['actual_total'].max()) + 5
+                ax.plot([lo, hi], [lo, hi], 'r--', linewidth=1, label='Perfect calibration')
+                ax.set_xlabel("Predicted Total")
+                ax.set_ylabel("Actual Total")
+                ax.set_title("Model Calibration")
+                ax.legend()
+                plt.tight_layout()
+                buf = io.BytesIO()
+                fig.savefig(buf, format='png', bbox_inches='tight')
+                buf.seek(0)
+                plt.close(fig)
+                st.image(buf.getvalue(), width=550)
+
+
+with tab4:
+    st.header("Model Insights")
+
+    MODEL_PATH = "model/rf_total_points_model_prod.joblib"
+
+    @st.cache_resource
+    def _load_model(path):
+        if os.path.exists(path):
+            return joblib.load(path)
+        return None
+
+    prod_model = _load_model(MODEL_PATH)
+
+    if prod_model is None:
+        st.info("Production model not found. Run `main.py` first to train and save the model.")
+    elif not hasattr(prod_model, "feature_importances_"):
+        st.info("Loaded model does not expose feature importances.")
+    else:
+        importances = prod_model.feature_importances_
+        feature_names = prod_model.feature_names_in_ if hasattr(prod_model, "feature_names_in_") else [
+            f"feature_{i}" for i in range(len(importances))
+        ]
+        fi_series = (
+            pd.Series(importances, index=feature_names)
+            .sort_values(ascending=True)
+            .tail(15)
+        )
+
+        fig, ax = plt.subplots(figsize=(7, 5))
+        bars = ax.barh(fi_series.index, fi_series.values, color='steelblue')
+        ax.set_xlabel("Importance")
+        ax.set_title("Top 15 Feature Importances (Production Model)")
+        for bar, val in zip(bars, fi_series.values):
+            ax.text(val + 0.001, bar.get_y() + bar.get_height() / 2,
+                    f"{val:.3f}", va='center', fontsize=8)
+        plt.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format='png', bbox_inches='tight')
+        buf.seek(0)
+        plt.close(fig)
+        st.image(buf.getvalue(), width=650)
+
+        st.caption(
+            "Feature importance is computed as mean decrease in impurity across all 500 decision trees. "
+            "Higher = the model leans on that feature more when making splits."
+        )

--- a/config.py
+++ b/config.py
@@ -1,0 +1,33 @@
+# ── Rolling window sizes ──────────────────────────────────────────────────────
+ROLLING_WINDOW_POINTS     = 3
+ROLLING_WINDOW_PACE       = 5
+ROLLING_WINDOW_QB         = 3
+ROLLING_WINDOW_DEF        = 3
+ROLLING_WINDOW_RZ         = 3
+ROLLING_WINDOW_TURNOVERS  = 3
+ROLLING_WINDOW_3RD_DOWN   = 3
+
+# ── Model hyperparameters ─────────────────────────────────────────────────────
+MODEL_N_ESTIMATORS = 500
+MODEL_MAX_DEPTH    = 8
+RANDOM_STATE       = 42
+
+# ── Evaluation ────────────────────────────────────────────────────────────────
+PRECISION_MARGIN = 4
+
+# ── Season lists ─────────────────────────────────────────────────────────────
+EVAL_TRAIN_SEASONS = list(range(2014, 2024))   # 2014–2023
+EVAL_TEST_SEASONS  = [2024]
+PROD_SEASONS       = list(range(2014, 2026))   # 2014–2025
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+TOTALS_PATH            = "data/nfl_over_unders.csv"
+WEATHER_FORECAST_PATH  = "data/nfl_weather_forecasts.csv"
+WEATHER_CACHE_DIR      = "data/weather_cache"
+EVAL_MODEL_PATH        = "model/rf_total_points_model_eval.joblib"
+PROD_MODEL_PATH        = "model/rf_total_points_model_prod.joblib"
+PREDICTIONS_DIR        = "predictions"
+
+# ── API reliability ───────────────────────────────────────────────────────────
+API_MAX_RETRIES    = 3
+API_BACKOFF_FACTOR = 1.5   # seconds multiplier between retries

--- a/main.py
+++ b/main.py
@@ -1,3 +1,8 @@
+import logging
+import os
+import argparse
+import sys
+
 from src.load import load_data
 from src.basic import create_basic_features
 from src.pace import create_pace_features
@@ -10,11 +15,30 @@ from src.weather_forecast import get_forecasted_weather
 from src.upcoming import prepare_upcoming_team_games
 from src.predictions import save_predictions
 from src.rest import create_rest_features
-from src.evaluate import evaluate_model
+from src.evaluate import evaluate_model, walk_forward_cv
 from src.redzone import create_red_zone
 from src.old_predictions import get_existing_predictions
-import argparse
-import sys
+from src.turnovers import create_turnover_features
+from src.third_down import create_third_down_features
+from config import (
+    EVAL_TRAIN_SEASONS, EVAL_TEST_SEASONS, PROD_SEASONS,
+    RANDOM_STATE, PRECISION_MARGIN,
+    EVAL_MODEL_PATH, PROD_MODEL_PATH,
+)
+
+
+def _setup_logging(log_dir: str = "logs") -> None:
+    os.makedirs(log_dir, exist_ok=True)
+    from datetime import datetime
+    log_file = os.path.join(log_dir, f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        handlers=[
+            logging.StreamHandler(),
+            logging.FileHandler(log_file),
+        ],
+    )
 
 
 def run_analysis(totals):
@@ -22,7 +46,7 @@ def run_analysis(totals):
     # Load historical play-level and game-level data using nfl_data_py
     games, plays = load_data()
 
-    # Add basic historical features like average points for/against 
+    # Add basic historical features like average points for/against
     team_games = create_basic_features(games)
 
     # Add QB EPA features
@@ -34,11 +58,17 @@ def run_analysis(totals):
     # Add pace features
     team_games = create_pace_features(team_games, plays)
 
-    # Add rest features
+    # Add rest features (short rest + post-bye)
     team_games = create_rest_features(team_games)
 
     # Add red zone efficiency feature
     team_games = create_red_zone(team_games, plays)
+
+    # Add offensive turnover rate (INTs + fumbles lost)
+    team_games = create_turnover_features(team_games, plays)
+
+    # Add third-down conversion rate
+    team_games = create_third_down_features(team_games, plays)
 
     # Add weather features
     team_games = create_weather_features(team_games)
@@ -46,54 +76,67 @@ def run_analysis(totals):
     # Load weather forecasts
     weather_features = get_forecasted_weather(totals)
 
-    # Train model for validation (holdout 2024)
+    # Train model for validation (holdout last season)
     model, X_test, y_test, features, test_data = train_model(
-        team_games = team_games,
-        model_path = "model/rf_total_points_model_eval.joblib",
-        train_seasons = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023],
-        test_seasons = [2024],
-        random_state = 42
+        team_games=team_games,
+        model_path=EVAL_MODEL_PATH,
+        train_seasons=EVAL_TRAIN_SEASONS,
+        test_seasons=EVAL_TEST_SEASONS,
+        random_state=RANDOM_STATE,
     )
 
-    # Evaluate model
+    # Single-season holdout evaluation
     evaluate_model(
         model,
         X_test,
         y_test,
         features,
         test_data,
-        precision_margin=4
+        precision_margin=PRECISION_MARGIN,
     )
 
-    # Production workflow: retrain using all available data (2021-2024)
+    # Walk-forward cross-validation for an honest multi-year accuracy picture
+    cv_results = walk_forward_cv(
+        team_games=team_games,
+        features=features,
+        precision_margin=PRECISION_MARGIN,
+        start_test_season=2018,
+    )
+    if not cv_results.empty:
+        logging.getLogger(__name__).info(
+            "Walk-forward CV summary:\n%s", cv_results.to_string(index=False)
+        )
+
+    # Production workflow: retrain using all available data
     prod_model, _, _, _, _ = train_model(
-        team_games = team_games,
-        model_path = "model/rf_total_points_model_prod.joblib",
-        train_seasons = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025],
-        test_seasons = [],  # No test set for production
-        random_state = 42
+        team_games=team_games,
+        model_path=PROD_MODEL_PATH,
+        train_seasons=PROD_SEASONS,
+        test_seasons=[],
+        random_state=RANDOM_STATE,
     )
 
-    # fetch existing predictions
+    # Fetch existing predictions
     existing_predictions = get_existing_predictions()
 
-    # prepare upcoming games data frame and make new predictions
+    # Prepare upcoming games data frame and make new predictions
     upcoming_team_games = prepare_upcoming_team_games(
         totals,
         team_games,
         latest_qb_epa,
         weather_features,
         prod_model,
-        existing_predictions
+        existing_predictions,
     )
 
-    # Use model to generate predictions for upcoming games (and add points scored in completed games)
+    # Save predictions (and merge actuals for completed games)
     predictions = save_predictions(existing_predictions, upcoming_team_games, games)
 
     return predictions
 
 
 if __name__ == "__main__":
+    _setup_logging()
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--use_cached_totals", action="store_true",

--- a/src/basic.py
+++ b/src/basic.py
@@ -1,4 +1,8 @@
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
+
 
 def create_basic_features(games):
     """Create team-game level features from games and play-by-play data."""
@@ -46,5 +50,5 @@ def create_basic_features(games):
     team_games['away_rolling_avg_points_for'] = team_games.groupby('game_id')['rolling_avg_points_for'].transform(lambda x: x.where(team_games['is_home']==0).max())
     team_games['away_rolling_avg_points_against'] = team_games.groupby('game_id')['rolling_avg_points_against'].transform(lambda x: x.where(team_games['is_home']==0).max())
 
-    print("Basic football features created.")
+    logger.info("Basic football features created.")
     return team_games

--- a/src/defense.py
+++ b/src/defense.py
@@ -1,4 +1,8 @@
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
+
 
 def create_defense_features(team_games: pd.DataFrame, plays: pd.DataFrame) -> pd.DataFrame:
     """
@@ -49,6 +53,6 @@ def create_defense_features(team_games: pd.DataFrame, plays: pd.DataFrame) -> pd
     team_games = team_games.merge(home_def_features, on='game_id', how='left')
     team_games = team_games.merge(away_def_features, on='game_id', how='left')
 
-    print("Team defense EPA features created.")
+    logger.info("Team defense EPA features created.")
 
     return team_games

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,5 +1,11 @@
+import logging
 import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import mean_absolute_error, r2_score
+from config import MODEL_N_ESTIMATORS, MODEL_MAX_DEPTH, RANDOM_STATE
+
+logger = logging.getLogger(__name__)
+
 
 def evaluate_model(model, X_test, y_test, features, test_data, precision_margin):
     """
@@ -13,8 +19,7 @@ def evaluate_model(model, X_test, y_test, features, test_data, precision_margin)
 
     mae = mean_absolute_error(y_test_total, y_pred_total)
     r2 = r2_score(y_test_total, y_pred_total)
-    print(f"MAE: {mae:.2f}")
-    print(f"R2: {r2:.3f}")
+    logger.info("Holdout MAE: %.2f  R²: %.3f", mae, r2)
 
     results = {"MAE": mae, "R2": r2}
 
@@ -33,6 +38,9 @@ def evaluate_model(model, X_test, y_test, features, test_data, precision_margin)
         "Correct Predictions": int(correct_predictions),
         "Precision": precision
     })
+    logger.info("Precision at ±%d pts: %s/%s = %.1f%%",
+                precision_margin, int(correct_predictions), int(num_predictions),
+                (precision or 0) * 100)
 
     # Feature importance
     if hasattr(model, "feature_importances_"):
@@ -40,7 +48,99 @@ def evaluate_model(model, X_test, y_test, features, test_data, precision_margin)
             model.feature_importances_, index=features
         ).sort_values(ascending=False)
         results["Feature Importance"] = feature_importance.to_dict()
-    
-    print(results)
 
     return results
+
+
+def walk_forward_cv(
+    team_games: pd.DataFrame,
+    features: list,
+    precision_margin: int = 4,
+    start_test_season: int = 2018,
+) -> pd.DataFrame:
+    """
+    Walk-forward (expanding window) cross-validation.
+
+    For each season >= start_test_season, train on ALL prior seasons and
+    evaluate on that season.  Returns a DataFrame with per-season metrics so
+    you can see whether accuracy is stable across years.
+
+    Parameters
+    ----------
+    team_games : pd.DataFrame
+        Full team-game dataset (same one passed to train_model).
+    features : list
+        Feature column names used by the model (including interaction terms
+        if they should be computed here).
+    precision_margin : int
+        Minimum |predicted - Vegas| to count as a signal.
+    start_test_season : int
+        First season to use as a test fold.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns: season, mae, r2, n_signals, n_correct, precision
+    """
+    # Build model-ready data (mirrors logic in train_model)
+    model_data = team_games.loc[
+        team_games["is_home"] == 1,
+        ["game_id", "season", "week", "total_points"] + features
+    ].copy().dropna(subset=features + ["total_points"])
+
+    model_data['residual'] = model_data['total_points'] - model_data['total_line']
+
+    all_seasons = sorted(model_data['season'].unique())
+    test_seasons = [s for s in all_seasons if s >= start_test_season]
+
+    rows = []
+    for test_season in test_seasons:
+        train_data = model_data[model_data['season'] < test_season]
+        test_data  = model_data[model_data['season'] == test_season]
+
+        if len(train_data) < 50 or test_data.empty:
+            continue
+
+        X_tr, y_tr = train_data[features], train_data['residual']
+        X_te, y_te = test_data[features],  test_data['residual']
+
+        m = RandomForestRegressor(
+            n_estimators=MODEL_N_ESTIMATORS,
+            max_depth=MODEL_MAX_DEPTH,
+            random_state=RANDOM_STATE
+        )
+        m.fit(X_tr, y_tr)
+
+        vegas  = X_te['total_line'].values
+        y_pred = vegas + m.predict(X_te)
+        y_true = vegas + y_te.values
+
+        mae = mean_absolute_error(y_true, y_pred)
+        r2  = r2_score(y_true, y_pred)
+
+        over_sig  = y_pred > vegas + precision_margin
+        under_sig = y_pred < vegas - precision_margin
+        signals   = over_sig | under_sig
+        n_signals = int(signals.sum())
+        n_correct = int(
+            (((y_true > vegas) & over_sig) | ((y_true < vegas) & under_sig)).sum()
+        )
+        prec = n_correct / n_signals if n_signals > 0 else None
+
+        rows.append({
+            'season':    test_season,
+            'mae':       round(mae, 2),
+            'r2':        round(r2, 3),
+            'n_signals': n_signals,
+            'n_correct': n_correct,
+            'precision': round(prec, 3) if prec is not None else None,
+        })
+        logger.info("CV %d — MAE: %.2f  R²: %.3f  Precision: %s/%s",
+                    test_season, mae, r2, n_correct, n_signals)
+
+    cv_results = pd.DataFrame(rows)
+    if not cv_results.empty:
+        avg = cv_results[['mae', 'r2', 'precision']].mean()
+        logger.info("Walk-forward CV averages — MAE: %.2f  R²: %.3f  Precision: %.3f",
+                    avg['mae'], avg['r2'], avg['precision'])
+    return cv_results

--- a/src/load.py
+++ b/src/load.py
@@ -1,8 +1,9 @@
+import logging
 import os
 import pandas as pd
 
-import os
-import pandas as pd
+logger = logging.getLogger(__name__)
+
 
 def load_data():
     """Load cached NFL game-level and play-by-play data from CSV files in the data directory."""
@@ -15,10 +16,10 @@ def load_data():
             "Data files not found. Please run the data download script first to generate games.csv and plays.csv in the data directory."
         )
 
-    print(f"Reading cached historical game-level data from {games_path}...")
+    logger.info("Reading historical game-level data from %s...", games_path)
     games = pd.read_parquet(games_path)
 
-    print(f"Reading cached historical play-level data from {plays_path}...")
+    logger.info("Reading historical play-level data from %s...", plays_path)
     plays = pd.read_parquet(plays_path)
 
     return games, plays

--- a/src/old_predictions.py
+++ b/src/old_predictions.py
@@ -1,6 +1,10 @@
+import logging
 import os
 import re
 import pandas as pd
+
+logger = logging.getLogger(__name__)
+
 
 def get_existing_predictions(predictions_dir="predictions"):
     """
@@ -8,14 +12,13 @@ def get_existing_predictions(predictions_dir="predictions"):
     Returns its contents as a pandas DataFrame, or an empty DataFrame if no files exist.
     """
     if not os.path.exists(predictions_dir):
-        print(f"No directory found at {predictions_dir}")
-        return pd.DataFrame()  # return empty DataFrame
-    
-    # List all matching prediction files
+        logger.info("No directory found at %s", predictions_dir)
+        return pd.DataFrame()
+
     files = [f for f in os.listdir(predictions_dir) if re.match(r"predictions_\d{8}(_v\d+)?\.csv", f)]
     if not files:
-        print("No prediction files found.")
-        return pd.DataFrame()  # return empty DataFrame
+        logger.info("No prediction files found.")
+        return pd.DataFrame()
 
     # Function to sort by date and version number
     def file_key(f):
@@ -34,5 +37,5 @@ def get_existing_predictions(predictions_dir="predictions"):
     if 'date' in df.columns:
         df['date'] = pd.to_datetime(df['date']).dt.date
     
-    print(f"Loaded existing predictions from {latest_path}")
+    logger.info("Loaded existing predictions from %s", latest_path)
     return df

--- a/src/pace.py
+++ b/src/pace.py
@@ -1,4 +1,9 @@
+import logging
 import pandas as pd
+from config import ROLLING_WINDOW_PACE
+
+logger = logging.getLogger(__name__)
+
 
 def create_pace_features(team_games: pd.DataFrame, pbp: pd.DataFrame) -> pd.DataFrame:
     # --- build pace dataset ---
@@ -11,12 +16,13 @@ def create_pace_features(team_games: pd.DataFrame, pbp: pd.DataFrame) -> pd.Data
     )
 
     plays_per_game["seconds_per_play"] = 3600 / plays_per_game["plays"]
-
     plays_per_game = plays_per_game.sort_values(["posteam", "game_id"])
 
+    # Shift before rolling to avoid including the current game (leakage fix)
     plays_per_game["rolling_avg_off_pace"] = (
         plays_per_game.groupby("posteam")["seconds_per_play"]
-        .transform(lambda x: x.rolling(5, min_periods=1).mean())
+        .apply(lambda x: x.shift().rolling(ROLLING_WINDOW_PACE, min_periods=1).mean())
+        .reset_index(level=0, drop=True)
     )
 
     # --- merge directly onto team_games ---
@@ -37,6 +43,6 @@ def create_pace_features(team_games: pd.DataFrame, pbp: pd.DataFrame) -> pd.Data
     team_games["home_rolling_avg_off_pace"] = team_games.groupby("game_id")["home_rolling_avg_off_pace"].transform("max")
     team_games["away_rolling_avg_off_pace"] = team_games.groupby("game_id")["away_rolling_avg_off_pace"].transform("max")
 
-    print("Team pace features created.")
+    logger.info("Team pace features created.")
 
     return team_games

--- a/src/predictions.py
+++ b/src/predictions.py
@@ -1,6 +1,10 @@
+import logging
 import pandas as pd
 import os
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
 
 def save_predictions(existing_predictions: pd.DataFrame,
                      upcoming_team_games: pd.DataFrame,
@@ -12,7 +16,7 @@ def save_predictions(existing_predictions: pd.DataFrame,
     Saves output to predictions/predictions_YYYYMMDD[_vN].csv
     """
     if upcoming_team_games is None or upcoming_team_games.empty:
-        print("No new upcoming games to predict. Exiting function.")
+        logger.info("No new upcoming games to predict. Exiting function.")
         return None
 
     existing_predictions = existing_predictions.copy()
@@ -72,6 +76,6 @@ def save_predictions(existing_predictions: pd.DataFrame,
 
     combined.to_csv(filepath, index=False)
 
-    print(f"Predictions saved to {filepath}")
+    logger.info("Predictions saved to %s", filepath)
 
     return combined

--- a/src/qb.py
+++ b/src/qb.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def create_qb_features(team_games, plays):
     """
@@ -85,6 +89,6 @@ def create_qb_features(team_games, plays):
     team_games = team_games.merge(home_qb_features, on='game_id', how='left')
     team_games = team_games.merge(away_qb_features, on='game_id', how='left')
 
-    print("QB EPA features created.")
+    logger.info("QB EPA features created.")
 
     return team_games, latest_qb_epa

--- a/src/redzone.py
+++ b/src/redzone.py
@@ -1,4 +1,8 @@
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
+
 
 def create_red_zone(team_games: pd.DataFrame, plays: pd.DataFrame) -> pd.DataFrame:
     """
@@ -95,6 +99,6 @@ def create_red_zone(team_games: pd.DataFrame, plays: pd.DataFrame) -> pd.DataFra
     team_games = team_games.merge(home_features, on="game_id", how="left")
     team_games = team_games.merge(away_features, on="game_id", how="left")
 
-    print("Red zone rolling efficiency features created: home_rolling_rz_eff, away_rolling_rz_eff")
+    logger.info("Red zone rolling efficiency features created: home_rolling_rz_eff, away_rolling_rz_eff")
 
     return team_games

--- a/src/rest.py
+++ b/src/rest.py
@@ -1,45 +1,60 @@
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
+
 
 def create_rest_features(team_games: pd.DataFrame) -> pd.DataFrame:
     """
-    Adds short rest flags (<= 6 days between games) for home and away teams.
+    Adds rest-based flags for home and away teams:
+      - short_rest  : <= 6 days since last game (e.g. Thursday games)
+      - post_bye    : 11–21 days since last game within the same season
+      - both_short_rest : both teams on short rest
 
     Parameters
     ----------
     team_games : pd.DataFrame
-        Team-level game data (must include game_id, team, game_date).
-    model_data : pd.DataFrame
-        Modeling dataset keyed by game_id, home_team, away_team.
-    features : list
-        Current feature list to be updated in-place.
+        Team-level game data (must include game_id, team, date, season).
 
     Returns
     -------
-    model_data : pd.DataFrame
-        Updated with home_short_rest, away_short_rest, both_short_rest.
+    pd.DataFrame
+        Updated with home_short_rest, away_short_rest, both_short_rest,
+        home_post_bye, away_post_bye.
     """
     tg = team_games.copy()
     tg['game_date'] = pd.to_datetime(tg['date'])
     tg = tg.sort_values(['team', 'game_date'])
+
+    # Days since last game across all seasons (cross-season gaps will be large)
     tg['days_since_last_game'] = tg.groupby('team')['game_date'].diff().dt.days
+
     tg['short_rest'] = (tg['days_since_last_game'] <= 6).astype(int)
 
-    # Home team rest features
+    # Bye week: exactly one extra week off within a season (11–21 day gap).
+    # Cross-season gaps are much larger so they don't false-positive here.
+    tg['post_bye'] = (
+        (tg['days_since_last_game'] >= 11) & (tg['days_since_last_game'] <= 21)
+    ).astype(int)
+
+    # Home team
     home_rest = (
-        tg.loc[tg['is_home'] == 1, ['game_id', 'short_rest']]
-        .rename(columns={'short_rest': 'home_short_rest'})
+        tg.loc[tg['is_home'] == 1, ['game_id', 'short_rest', 'post_bye']]
+        .rename(columns={'short_rest': 'home_short_rest', 'post_bye': 'home_post_bye'})
     )
 
-    # Away team rest features
+    # Away team
     away_rest = (
-        tg.loc[tg['is_home'] == 0, ['game_id', 'short_rest']]
-        .rename(columns={'short_rest': 'away_short_rest'})
+        tg.loc[tg['is_home'] == 0, ['game_id', 'short_rest', 'post_bye']]
+        .rename(columns={'short_rest': 'away_short_rest', 'post_bye': 'away_post_bye'})
     )
 
-    # Merge into team_games
     team_games = team_games.merge(home_rest, on='game_id', how='left')
     team_games = team_games.merge(away_rest, on='game_id', how='left')
 
-    team_games['both_short_rest'] = ((team_games['home_short_rest'] == 1) & (team_games['away_short_rest'] == 1)).astype(int)
+    team_games['both_short_rest'] = (
+        (team_games['home_short_rest'] == 1) & (team_games['away_short_rest'] == 1)
+    ).astype(int)
 
+    logger.info("Rest features created: home/away short_rest, post_bye, both_short_rest")
     return team_games

--- a/src/third_down.py
+++ b/src/third_down.py
@@ -1,0 +1,58 @@
+import logging
+import pandas as pd
+from config import ROLLING_WINDOW_3RD_DOWN
+
+logger = logging.getLogger(__name__)
+
+
+def create_third_down_features(team_games: pd.DataFrame, plays: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add rolling third-down conversion rate per game.
+    Rolling window is ROLLING_WINDOW_3RD_DOWN games, shifted to use only prior games.
+    Adds: home_rolling_avg_3rd_pct, away_rolling_avg_3rd_pct
+    """
+    req = {'third_down_attempt', 'third_down_converted'}
+    if not req.issubset(plays.columns):
+        missing = req - set(plays.columns)
+        logger.warning("Missing third-down columns %s — filling with 0.40 league average.", missing)
+        team_games['rolling_avg_3rd_pct']      = 0.40
+        team_games['home_rolling_avg_3rd_pct'] = 0.40
+        team_games['away_rolling_avg_3rd_pct'] = 0.40
+        return team_games
+
+    third_downs = plays[plays['third_down_attempt'] == 1]
+
+    game_3rd = (
+        third_downs
+        .groupby(['game_id', 'posteam'])
+        .agg(attempts=('third_down_attempt', 'sum'),
+             conversions=('third_down_converted', 'sum'))
+        .reset_index()
+        .rename(columns={'posteam': 'team'})
+    )
+    game_3rd['3rd_pct'] = game_3rd['conversions'] / game_3rd['attempts'].replace(0, float('nan'))
+
+    team_games = team_games.merge(game_3rd[['game_id', 'team', '3rd_pct']], on=['game_id', 'team'], how='left')
+    team_games = team_games.sort_values(['team', 'season', 'week'])
+
+    team_games['rolling_avg_3rd_pct'] = (
+        team_games
+        .groupby(['team', 'season'])['3rd_pct']
+        .apply(lambda x: x.shift().rolling(ROLLING_WINDOW_3RD_DOWN, min_periods=1).mean())
+        .reset_index(level=[0, 1], drop=True)
+    )
+
+    home_feat = (
+        team_games.loc[team_games['is_home'] == 1, ['game_id', 'rolling_avg_3rd_pct']]
+        .rename(columns={'rolling_avg_3rd_pct': 'home_rolling_avg_3rd_pct'})
+    )
+    away_feat = (
+        team_games.loc[team_games['is_home'] == 0, ['game_id', 'rolling_avg_3rd_pct']]
+        .rename(columns={'rolling_avg_3rd_pct': 'away_rolling_avg_3rd_pct'})
+    )
+
+    team_games = team_games.merge(home_feat, on='game_id', how='left')
+    team_games = team_games.merge(away_feat, on='game_id', how='left')
+
+    logger.info("Third-down features created: home_rolling_avg_3rd_pct, away_rolling_avg_3rd_pct")
+    return team_games

--- a/src/totals.py
+++ b/src/totals.py
@@ -1,12 +1,17 @@
+import logging
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import pandas as pd
 import os
 from dotenv import load_dotenv
 from datetime import datetime, timedelta
 from pytz import timezone as tz
+from config import TOTALS_PATH, API_MAX_RETRIES, API_BACKOFF_FACTOR
 
+logger = logging.getLogger(__name__)
 
-DATA_PATH = "data/nfl_over_unders.csv"
+DATA_PATH = TOTALS_PATH
 
 load_dotenv()
 API_KEY = os.getenv("API_KEY_TOTALS")
@@ -15,12 +20,27 @@ if not API_KEY:
     raise ValueError("Missing API_KEY_TOTALS in .env file")
 
 
+def _session() -> requests.Session:
+    """Return a requests Session with automatic retry on transient errors."""
+    s = requests.Session()
+    retry = Retry(
+        total=API_MAX_RETRIES,
+        backoff_factor=API_BACKOFF_FACTOR,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
 def get_totals_from_api(api_key=API_KEY):
     url = (
         f"https://api.the-odds-api.com/v4/sports/americanfootball_nfl/odds/"
         f"?apiKey={api_key}&regions=us&markets=totals&oddsFormat=american"
     )
-    resp = requests.get(url)
+    resp = _session().get(url, timeout=30)
     resp.raise_for_status()
     data = resp.json()
     games = []
@@ -71,7 +91,7 @@ def get_totals(path=DATA_PATH, api_key=API_KEY, use_cache_only=False):
     eastern = tz("US/Eastern")
 
     if os.path.exists(path):
-        print(f"Reading existing Vegas totals from {path}...")
+        logger.info("Reading existing Vegas totals from %s...", path)
         existing_df = pd.read_csv(path)
 
         # Normalize datetime
@@ -79,17 +99,17 @@ def get_totals(path=DATA_PATH, api_key=API_KEY, use_cache_only=False):
         existing_df['commence_time'] = existing_df['commence_time'].dt.tz_convert(eastern)
 
         if use_cache_only:
-            print("Using cached totals only. Skipping API fetch.")
+            logger.info("Using cached totals only. Skipping API fetch.")
             return existing_df
 
         # Get new data
-        print("Fetching new and updated game totals from API...")
+        logger.info("Fetching new and updated game totals from API...")
         new_df = get_totals_from_api(api_key)
 
         # Normalize new datetime
         new_df['commence_time'] = pd.to_datetime(new_df['commence_time'], utc=True)
         new_df['commence_time'] = new_df['commence_time'].dt.tz_convert(eastern)
-        
+
         # Combine and drop duplicates
         combined = pd.concat([existing_df, new_df], ignore_index=True)
         combined = combined.drop_duplicates(
@@ -98,14 +118,14 @@ def get_totals(path=DATA_PATH, api_key=API_KEY, use_cache_only=False):
         ).sort_values(by='commence_time')
 
         combined.to_csv(path, index=False)
-        print(f"Appended new games. Saved updated file to {path}.")
+        logger.info("Appended new games. Saved updated file to %s.", path)
         return combined
 
     else:
         if use_cache_only:
             raise FileNotFoundError(f"No cached file found at {path}, cannot skip API fetch.")
-        print("No existing file found. Downloading fresh totals...")
+        logger.info("No existing file found. Downloading fresh totals...")
         df = get_totals_from_api(api_key)
         df.to_csv(path, index=False)
-        print(f"Saved new file to {path}.")
+        logger.info("Saved new file to %s.", path)
         return df

--- a/src/train.py
+++ b/src/train.py
@@ -1,8 +1,12 @@
+import logging
 import joblib
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import mean_absolute_error, r2_score
+from config import MODEL_N_ESTIMATORS, MODEL_MAX_DEPTH
+
+logger = logging.getLogger(__name__)
 
 
 def train_model(
@@ -31,7 +35,7 @@ def train_model(
 
     # Features for prediction
     features = [
-        "total_line", # Vegas total for benchmarking
+        "total_line",                        # Vegas total (benchmark prior)
         "home_rolling_avg_points_for",
         "home_rolling_avg_points_against",
         "away_rolling_avg_points_for",
@@ -50,8 +54,14 @@ def train_model(
         "home_short_rest",
         "away_short_rest",
         "both_short_rest",
+        "home_post_bye",                     # team coming off a bye week
+        "away_post_bye",
         "home_rolling_rz_eff",
-        "away_rolling_rz_eff"
+        "away_rolling_rz_eff",
+        "home_rolling_avg_turnovers",        # offensive turnover rate (INT + fumbles lost)
+        "away_rolling_avg_turnovers",
+        "home_rolling_avg_3rd_pct",          # third-down conversion rate
+        "away_rolling_avg_3rd_pct",
     ]
 
    # Keep one row per game (home team)
@@ -89,8 +99,8 @@ def train_model(
 
     # Fit model
     model = RandomForestRegressor(
-        n_estimators=500,
-        max_depth=8,
+        n_estimators=MODEL_N_ESTIMATORS,
+        max_depth=MODEL_MAX_DEPTH,
         random_state=random_state
     )
     model.fit(X_train, y_train)
@@ -98,6 +108,6 @@ def train_model(
     # Save trained model
     joblib.dump(model, model_path)
 
-    print("Model has been trained.")
+    logger.info("Model trained and saved to %s.", model_path)
 
     return model, X_test, y_test, features, test_data

--- a/src/turnovers.py
+++ b/src/turnovers.py
@@ -1,0 +1,55 @@
+import logging
+import pandas as pd
+from config import ROLLING_WINDOW_TURNOVERS
+
+logger = logging.getLogger(__name__)
+
+
+def create_turnover_features(team_games: pd.DataFrame, plays: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add rolling offensive turnover rate (INTs + fumbles lost) per game.
+    Rolling window is ROLLING_WINDOW_TURNOVERS games, shifted to use only prior games.
+    Adds: home_rolling_avg_turnovers, away_rolling_avg_turnovers
+    """
+    available_cols = [c for c in ('interception', 'fumble_lost') if c in plays.columns]
+
+    if not available_cols:
+        logger.warning("No turnover columns found in plays data — filling with zeros.")
+        team_games['rolling_avg_turnovers']      = 0.0
+        team_games['home_rolling_avg_turnovers'] = 0.0
+        team_games['away_rolling_avg_turnovers'] = 0.0
+        return team_games
+
+    game_turnovers = (
+        plays
+        .groupby(['game_id', 'posteam'])[available_cols]
+        .sum()
+        .sum(axis=1)
+        .reset_index(name='turnovers')
+        .rename(columns={'posteam': 'team'})
+    )
+
+    team_games = team_games.merge(game_turnovers, on=['game_id', 'team'], how='left')
+    team_games = team_games.sort_values(['team', 'season', 'week'])
+
+    team_games['rolling_avg_turnovers'] = (
+        team_games
+        .groupby(['team', 'season'])['turnovers']
+        .apply(lambda x: x.shift().rolling(ROLLING_WINDOW_TURNOVERS, min_periods=1).mean())
+        .reset_index(level=[0, 1], drop=True)
+    )
+
+    home_feat = (
+        team_games.loc[team_games['is_home'] == 1, ['game_id', 'rolling_avg_turnovers']]
+        .rename(columns={'rolling_avg_turnovers': 'home_rolling_avg_turnovers'})
+    )
+    away_feat = (
+        team_games.loc[team_games['is_home'] == 0, ['game_id', 'rolling_avg_turnovers']]
+        .rename(columns={'rolling_avg_turnovers': 'away_rolling_avg_turnovers'})
+    )
+
+    team_games = team_games.merge(home_feat, on='game_id', how='left')
+    team_games = team_games.merge(away_feat, on='game_id', how='left')
+
+    logger.info("Turnover features created: home_rolling_avg_turnovers, away_rolling_avg_turnovers")
+    return team_games

--- a/src/upcoming.py
+++ b/src/upcoming.py
@@ -1,5 +1,9 @@
+import logging
 import pandas as pd
 import pytz
+
+logger = logging.getLogger(__name__)
+
 
 def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
                                 weather_features, model, existing_predictions=None):
@@ -54,7 +58,7 @@ def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
         upcoming_games = upcoming_games.drop(columns=['_merge', 'pred_date'], errors='ignore')
 
         if upcoming_games.empty:
-            print("All upcoming games are already in existing predictions.")
+            logger.info("All upcoming games are already in existing predictions.")
             return pd.DataFrame()
 
     # Divisional matchups
@@ -99,18 +103,47 @@ def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
     # Rest features
     upcoming_games['both_short_rest'] = ((upcoming_games['home_short_rest'] == 1) & (upcoming_games['away_short_rest'] == 1)).astype(int)
 
+    # --- Post-bye flag: compute from last historical game date vs upcoming date ---
+    last_game = (
+        team_games_hist
+        .sort_values('date')
+        .groupby('team')['date']
+        .last()
+        .reset_index()
+        .rename(columns={'date': 'last_game_date'})
+    )
+    last_game['last_game_date'] = pd.to_datetime(last_game['last_game_date']).dt.tz_localize(None)
+
+    upcoming_dt = pd.to_datetime(upcoming_games['commence_time'], utc=True).dt.tz_localize(None)
+
+    # Home post-bye
+    upcoming_games = upcoming_games.merge(last_game.rename(columns={'team': 'home_team'}),
+                                          on='home_team', how='left')
+    home_gap = (upcoming_dt - upcoming_games['last_game_date'].values).dt.days
+    upcoming_games['home_post_bye'] = ((home_gap >= 11) & (home_gap <= 21)).astype(int)
+    upcoming_games.drop(columns=['last_game_date'], inplace=True)
+
+    # Away post-bye
+    upcoming_games = upcoming_games.merge(last_game.rename(columns={'team': 'away_team'}),
+                                          on='away_team', how='left')
+    away_gap = (upcoming_dt - upcoming_games['last_game_date'].values).dt.days
+    upcoming_games['away_post_bye'] = ((away_gap >= 11) & (away_gap <= 21)).astype(int)
+    upcoming_games.drop(columns=['last_game_date'], inplace=True)
+
     upcoming_games = upcoming_games.loc[:, ~upcoming_games.columns.duplicated()]
 
     # Split home/away for features
     home = upcoming_games[['commence_time', 'home_team', 'away_team', 'total_line',
                            'home_rolling_avg_qb_epa', 'divisional', 'regular_season',
-                           'international', 'home_short_rest', 'away_short_rest', 'both_short_rest']].copy()
+                           'international', 'home_short_rest', 'away_short_rest', 'both_short_rest',
+                           'home_post_bye', 'away_post_bye']].copy()
     home.rename(columns={'home_team':'team', 'away_team':'opponent', 'commence_time':'date'}, inplace=True)
     home['is_home'] = 1
 
     away = upcoming_games[['commence_time', 'away_team', 'home_team', 'total_line',
                            'away_rolling_avg_qb_epa', 'divisional', 'regular_season',
-                           'international', 'home_short_rest', 'away_short_rest', 'both_short_rest']].copy()
+                           'international', 'home_short_rest', 'away_short_rest', 'both_short_rest',
+                           'home_post_bye', 'away_post_bye']].copy()
     away.rename(columns={'away_team':'team', 'home_team':'opponent', 'commence_time':'date'}, inplace=True)
     away['is_home'] = 0
 
@@ -127,7 +160,8 @@ def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
     # Merge rolling averages from historical team games
     rolling_features = [
         'rolling_avg_points_for', 'rolling_avg_points_against',
-        'rolling_avg_def_epa', 'rolling_avg_off_pace', 'rolling_rz_eff'
+        'rolling_avg_def_epa', 'rolling_avg_off_pace', 'rolling_rz_eff',
+        'rolling_avg_turnovers', 'rolling_avg_3rd_pct',
     ]
     for feat in rolling_features:
         last_vals = team_games_hist.groupby('team')[feat].last().reset_index()
@@ -166,7 +200,9 @@ def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
         'international_home': 'international',
         'home_short_rest_home': 'home_short_rest',
         'away_short_rest_home': 'away_short_rest',
-        'both_short_rest_home': 'both_short_rest'
+        'both_short_rest_home': 'both_short_rest',
+        'home_post_bye_home': 'home_post_bye',
+        'away_post_bye_home': 'away_post_bye',
     }, inplace=True)
 
     # Rename total_line from home so it exists
@@ -175,7 +211,8 @@ def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
     # Cleanup only truly redundant columns
     drop_cols = [
         'opponent_home', 'opponent_away', 'total_line_away', 'divisional_away', 'regular_season_away',
-        'international_away','home_short_rest_away','away_short_rest_away','both_short_rest_away'
+        'international_away', 'home_short_rest_away', 'away_short_rest_away', 'both_short_rest_away',
+        'home_post_bye_away', 'away_post_bye_away',
     ]
     game_features.drop(columns=drop_cols, inplace=True, errors='ignore')
 
@@ -196,12 +233,18 @@ def prepare_upcoming_team_games(upcoming_games, team_games_hist, latest_qb_epa,
         'rolling_avg_off_pace_pre_game_away': 'away_rolling_avg_off_pace',
         'divisional': 'divisional',
         'regular_season': 'regular_season',
-        'international' : 'international',
+        'international': 'international',
         'home_short_rest': 'home_short_rest',
         'away_short_rest': 'away_short_rest',
         'both_short_rest': 'both_short_rest',
-        'rolling_rz_eff_pre_game_home' : 'home_rolling_rz_eff',
-        'rolling_rz_eff_pre_game_away' : 'away_rolling_rz_eff'
+        'home_post_bye': 'home_post_bye',
+        'away_post_bye': 'away_post_bye',
+        'rolling_rz_eff_pre_game_home': 'home_rolling_rz_eff',
+        'rolling_rz_eff_pre_game_away': 'away_rolling_rz_eff',
+        'rolling_avg_turnovers_pre_game_home': 'home_rolling_avg_turnovers',
+        'rolling_avg_turnovers_pre_game_away': 'away_rolling_avg_turnovers',
+        'rolling_avg_3rd_pct_pre_game_home': 'home_rolling_avg_3rd_pct',
+        'rolling_avg_3rd_pct_pre_game_away': 'away_rolling_avg_3rd_pct',
     }
     game_features = game_features.rename(columns=feature_mapping)
 

--- a/src/weather.py
+++ b/src/weather.py
@@ -1,6 +1,10 @@
+import logging
 import os
 import pandas as pd
 from meteostat import Point, Daily
+
+logger = logging.getLogger(__name__)
+
 
 def create_weather_features(team_games, cache_dir="data/weather_cache"):
     """
@@ -109,5 +113,5 @@ def create_weather_features(team_games, cache_dir="data/weather_cache"):
     team_games['home_temperature'] = pd.to_numeric(team_games['home_temperature'], errors='coerce')
     team_games['home_wind_speed'] = pd.to_numeric(team_games['home_wind_speed'], errors='coerce')
 
-    print("Weather features created.")
+    logger.info("Weather features created.")
     return team_games

--- a/src/weather_forecast.py
+++ b/src/weather_forecast.py
@@ -1,10 +1,31 @@
+import logging
 import os
 import pandas as pd
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from datetime import datetime, timezone
 from dotenv import load_dotenv
+from config import WEATHER_FORECAST_PATH, API_MAX_RETRIES, API_BACKOFF_FACTOR
 
-WEATHER_PATH = "data/nfl_weather_forecasts.csv"
+logger = logging.getLogger(__name__)
+
+WEATHER_PATH = WEATHER_FORECAST_PATH
+
+
+def _session() -> requests.Session:
+    """Return a requests Session with automatic retry on transient errors."""
+    s = requests.Session()
+    retry = Retry(
+        total=API_MAX_RETRIES,
+        backoff_factor=API_BACKOFF_FACTOR,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
 
 # Mapping full team names -> 3-letter abbreviations
 TEAM_ABBREV = {
@@ -85,7 +106,7 @@ def fetch_game_weather(home_team, kickoff_time, api_key):
             f"http://api.openweathermap.org/data/2.5/forecast"
             f"?lat={coords['lat']}&lon={coords['lon']}&appid={api_key}&units=imperial"
         )
-        response = requests.get(url)
+        response = _session().get(url, timeout=30)
         response.raise_for_status()
         data = response.json()
         forecasts = data["list"]
@@ -107,7 +128,7 @@ def fetch_game_weather(home_team, kickoff_time, api_key):
         }
 
     except Exception as e:
-        print(f"[ERROR] Weather fetch failed for {home_team} at {kickoff_time}: {e}")
+        logger.error("Weather fetch failed for %s at %s: %s", home_team, kickoff_time, e)
         return None
 
 def get_forecasted_weather(upcoming_team_games: pd.DataFrame) -> pd.DataFrame:
@@ -116,11 +137,10 @@ def get_forecasted_weather(upcoming_team_games: pd.DataFrame) -> pd.DataFrame:
     api_key = os.getenv("API_KEY_WEATHER")
     if not api_key:
         raise ValueError("Missing API_KEY_WEATHER in .env file")
-    
+
     if os.path.exists(WEATHER_PATH):
-        print(f"Reading cached weather forecast for upcoming games from {WEATHER_PATH}...")
+        logger.info("Reading cached weather forecast for upcoming games from %s...", WEATHER_PATH)
         df = pd.read_csv(WEATHER_PATH, parse_dates=['kickoff_time'])
-        # Ensure units are correct if reloading cached data
         if "temperature_F" in df.columns:
             df["temperature"] = (df["temperature_F"] - 32) * 5.0 / 9.0
         if "wind_speed_mph" in df.columns:
@@ -137,7 +157,6 @@ def get_forecasted_weather(upcoming_team_games: pd.DataFrame) -> pd.DataFrame:
             weather_data.append(result)
 
     df = pd.DataFrame(weather_data)
-    # No mapping needed, already abbreviations
     df.to_csv(WEATHER_PATH, index=False)
-    print(f"Saved weather forecast for upcoming games to {WEATHER_PATH}")
+    logger.info("Saved weather forecast for upcoming games to %s", WEATHER_PATH)
     return df


### PR DESCRIPTION
## What was done

### New files
| File | Purpose |
|---|---|
| `config.py` | Single source of truth for all magic numbers - rolling windows, season lists, model hyperparameters, paths, API retry settings |
| `src/turnovers.py` | Rolling offensive turnover rate (INTs + fumbles lost) - new model feature |
| `src/third_down.py` | Rolling third-down conversion rate - new model feature |

### Pipeline changes
| File | Change |
|---|---|
| `src/rest.py` | Added `home_post_bye` / `away_post_bye` flag (11-21 day gap = bye week) |
| `src/pace.py` | **Fixed data leakage** - added `.shift()` before the rolling window (current game's pace was being leaked into its own feature) |
| `src/train.py` | Added 6 new features (`home/away_post_bye`, `home/away_rolling_avg_turnovers`, `home/away_rolling_avg_3rd_pct`); uses config constants |
| `src/upcoming.py` | Computes post-bye from historical dates; new features flow through `rolling_features` loop and `feature_mapping` |
| `src/evaluate.py` | Added `walk_forward_cv()` - expanding-window cross-validation that prints per-season accuracy so the "70% accuracy" claim is testable across multiple years |
| `src/totals.py` | HTTP session with `urllib3` retry (3 attempts, 1.5s backoff) on 429/5xx |
| `src/weather_forecast.py` | Same retry logic; uses config path constant |
| `main.py` | Wires in new modules; calls `walk_forward_cv`; sets up file+console logging via `logging.basicConfig` |
| All `src/*.py` | `print()` ? `logging.getLogger(__name__)` throughout |

### App changes (`app.py`)
- **Edge column** - shows `+X.X` / `-X.X` deviation from Vegas line on every row
- **Color coding** - green highlight when edge ? +4 (lean over), red when ? ?4 (lean under)
- **Weekly accuracy trend** - line chart of over/under accuracy by week in the Performance tab
- **Calibration scatter** - predicted vs actual total for all completed games
- **New "Model Insights" tab** - horizontal bar chart of top 15 feature importances loaded directly from the production model (cached with `@st.cache_resource`)